### PR TITLE
Habilita el prop para passwords en caso de que no se declare explícitamente

### DIFF
--- a/src/BaseInput.js
+++ b/src/BaseInput.js
@@ -408,11 +408,12 @@ class BaseInput extends Component {
   renderControl() {
     const props = this.beforeRenderControl(this.props);
     if (this.isTextInput(this.props.type)) { // Si se necesita un TextInput
-      if (this.props.type === 'password') {
-        props.secureTextEntry = true;
-      } else {
+      if(this.props.type !== 'password'){
         props.keyboardType = mapTypeToKeyboardType[this.props.type];
+      }else if(props.secureTextEntry === undefined){
+        props.secureTextEntry = true;
       }
+
       props.returnKeyType = props.next ? 'next' : props.returnKeyType;
       props.returnKeyType = props.send ? 'send' : props.returnKeyType;
       props.value = this.props.value ? this.props.value : this.state.value;


### PR DESCRIPTION
Esto permite extender de manera más simple `BaseInput` para agregar funcionalidades al password input. Por ejemplo, un botón para habilitar/deshabilitar la máscara de password.

```
class PasswordField extends BaseInput {
   constructor(props) {
      super(props);
      this.state = {
        password: true,
        ...this.state,
      };
    }

    handlePressMaskIcon = () => {
      this.setState({ password: !this.state.password });
    }

    beforeRenderControl = props => {
      return Object.assign({}, props, { placeholder: this.state.placeholder, secureTextEntry: this.state.password });
     };

    render(){
      //Código para renderear el input custom
    }
}